### PR TITLE
Fix getLastChild when the last child is a virtual element

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,6 +135,15 @@ function getLastChild(node) {
         lastChild = nextChild;
     } while (nextChild = ve.nextSibling(nextChild));
 
+    // If the last child is a virtual element, return the end comment.
+    if (lastChild.nodeType === 8) {
+        var childNodes = ve.childNodes(lastChild);
+        if (childNodes) {
+            var beforeEnd = childNodes.length > 0 ? childNodes[childNodes.length - 1] : lastChild;
+            lastChild = beforeEnd.nextSibling;
+        }
+    }
+
     return lastChild;
 }
 


### PR DESCRIPTION
Before, this would cause nodes to be inserted after the virtual element's start tag instead of after its end tag.

Consider the following html:
```html
<!-- ko if: false -->
<!-- /ko -->
<!-- ko else -->
    <!-- ko if: false -->
        Don't show this
<!-- /ko --><!-- /ko -->
```

Once bound, it turns into:
```html
<!-- ko if: false --><!-- /ko -->
<!-- ko else --><!--ko if: __elseCondition__-->
    <!-- ko if: false --><!--/ko-->
        Don't show this
<!-- /ko --><!-- /ko -->
```

The problem is caused by the lack of nodes between the last two end tags.
You wouldn't typically write it this way, but it hinders minification.